### PR TITLE
fixed MailChimp request URL bug

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "Pizzly",
-  "description": "A Node Application to simplify OAuth",
+  "description": "A Node Application to simplify OAuth.",
   "image": "heroku/node",
   "repository": "https://github.com/Bearer/Pizzly",
   "keywords": ["OAuth", "node"],

--- a/integrations/slack.json
+++ b/integrations/slack.json
@@ -1,8 +1,8 @@
 {
   "name": "Slack",
   "auth": {
-    "authorizationURL": "https://slack.com/oauth/authorize",
-    "tokenURL": "https://slack.com/api/oauth.access",
+    "authorizationURL": "https://slack.com/oauth/v2/authorize",
+    "tokenURL": "https://slack.com/api/oauth.v2.access",
     "authType": "OAUTH2",
     "authorizationParams": { "access_type": "offline", "consent": true },
     "auth": {

--- a/src/lib/proxy/index.ts
+++ b/src/lib/proxy/index.ts
@@ -23,6 +23,7 @@ import { getOAuth1Credentials } from '../../legacy/api-config/request-config'
 export const incomingRequestHandler = async (req, res, next) => {
   // General inputs validation
   const authId = req.get('Pizzly-Auth-Id') || ''
+  const chimpDC = req.get('Chimp-Dc') || ''
   const integrationName = req.params.integration
 
   if (!authId) {
@@ -55,13 +56,18 @@ export const incomingRequestHandler = async (req, res, next) => {
     // i.e. replace ${auth.accessToken} from the integration template
     // with the authentication access token retrieved from the database.
     const forwardedHeaders = headersToForward(req.rawHeaders)
-    const { url, headers } = await buildRequest({
+    let { url, headers } = await buildRequest({
       authentication,
       integration,
       method: req.method,
       forwardedHeaders: forwardedHeaders,
       path: req.originalUrl.substring(('/proxy/' + integrationName).length + 1)
     })
+
+    //If there is a header in the request specifying the MailChimp datacenter, replace the "server" in the request URL with the datacenter name.
+    if (chimpDC) {
+      url = new URL(url.toString().replace('server', chimpDC))
+    }
 
     // Remove pizzly related params: ex
     url.searchParams.forEach((value, key) => {


### PR DESCRIPTION
## Proposed changes

Originally the MailChimp request URL used a fixed value "https://server.api.mailchimp.com/3.0/". This request URL doesn't exist so the request will fail. According to MC's docs, the server in the request URL should be the user's data center in use, for example, us2 and us6. So only something like https://us1.api.mailchimp.com/3.0/ will work.

The committed change in the proxy module tries to read a "Chimp-Dc" header, and if it exists, it will try to replace the "server" in the request value with the value provided by the "Chimp-Dc" header (for example, us1).

Also upgraded Slack Auth version from v1 to v2

## Types of changes


- [ ] Bugfix Fixing MailChimp integration request URL bug
- [ ] Bugfix Changing the Slack auth version to v2, the original configuration uses v1 and it is no longer maintained.
