### PR TITLE
Enable custom callback URL through an environment variable

### DIFF
--- a/packages/server/lib/utils/utils.ts
+++ b/packages/server/lib/utils/utils.ts
@@ -5,8 +5,10 @@ export function getPort() {
 }
 
 export function getOauthCallbackUrl() {
-    let port = getPort();
-    return (process.env['SERVER_HOST'] || 'http://localhost') + `:${port}` + '/oauth/callback';
+    return (
+        process.env['AUTH_CALLBACK_URL'] ||
+        ((process.env['SERVER_HOST'] || 'http://localhost') + `:${getPort()}` + '/oauth/callback')
+    );
 }
 
 // A helper function to interpolate a string.


### PR DESCRIPTION
In order to address the issue described here:
https://github.com/NangoHQ/Pizzly/issues/279

For a production deployment, where a single machine serves both pizzly and a web-app, it's not ideal to have to open two separate ports (one for pizzly, one for the app). Instead, a proxy can redirect traffic to the /oauth route towards pizzly. In those instances, it's helpful to customize the callback URL to point it to the proxy server.