### PR TITLE
Added typings to the frontend package.json

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -4,6 +4,7 @@
     "description": "Pizzly's frontend library for OAuth handling.",
     "type": "module",
     "main": "dist/index.js",
+    "typings": "dist/index.d.ts",
     "keywords": [],
     "author": "bastien@nango.dev",
     "repository": {


### PR DESCRIPTION
The `packages/frontend/package.json` was missing the typings key 