### PR TITLE
Added Airtable provider

### DIFF
--- a/packages/auth/lib/controllers/oauth.controller.ts
+++ b/packages/auth/lib/controllers/oauth.controller.ts
@@ -248,6 +248,9 @@ class OAuthController {
 
             return html(logger, res, providerConfigKey, connectionId, '', '');
         } catch (e) {
+            if (e instanceof Error) {
+                return html(logger, res, providerConfigKey, connectionId, 'token_err', this.errDesc['token_err'](e.message));
+            }
             return html(logger, res, providerConfigKey, connectionId, 'token_err', this.errDesc['token_err'](JSON.stringify(e)));
         }
     }

--- a/packages/auth/providers.yaml
+++ b/packages/auth/providers.yaml
@@ -1,3 +1,10 @@
+airtable:
+    auth_mode: OAUTH2
+    authorization_url: https://airtable.com/oauth2/v1/authorize
+    token_url: https://airtable.com/oauth2/v1/token
+    authorization_method: header
+    auth:
+        response_type: code
 asana:
     auth_mode: OAUTH2
     authorization_url: https://app.asana.com/-/oauth_authorize


### PR DESCRIPTION
I have tested the OAuth flow and can confirm that it works.

Additionally, `simpleOAuthClient.getToken()` in `oauth2Callback` can throw an Error object which can't be JSON.stringified. It was crashing the server. Now I check if the caught error is an Error and produce a different error output.