### PR TITLE
Integration shopify

### DIFF
--- a/packages/auth/providers.yaml
+++ b/packages/auth/providers.yaml
@@ -153,6 +153,10 @@ salesloft:
     auth_mode: OAUTH2
     authorization_url: https://accounts.salesloft.com/oauth/authorize
     token_url: https://accounts.salesloft.com/oauth/token
+shopify:
+    auth_mode: OAUTH2
+    authorization_url: https://${connectionConfig.params.subdomain}.myshopify.com/admin/oauth/authorize
+    token_url: https://${connectionConfig.params.subdomain}.myshopify.com/admin/oauth/access_token
 slack:
     auth_mode: OAUTH2
     authorization_url: https://slack.com/oauth/v2/authorize

--- a/packages/frontend/bin/sample.html
+++ b/packages/frontend/bin/sample.html
@@ -29,6 +29,12 @@ Then open http://localhost:8000/bin/sample.html in your browser
                 <label>Connection ID (reuse the ID of the entity initiating the connection, e.g. a user, company, etc.):</label>
                 <input type="text" id="connectionId" value="1" />
             </formgroup>
+            <br />
+            <br />
+            <formgroup>
+                <label>Optional extra params (e.g. some connections require a subdomain):</label>
+                <textarea type="text" id="params">{}</textarea>
+            </formgroup>
         </form>
         <p><button id="connect">Start OAuth flow</button></p>
         <div style="margin-top: 50px">
@@ -44,10 +50,14 @@ Then open http://localhost:8000/bin/sample.html in your browser
                 () => {
                     var providerConfigKey = document.getElementById('providerConfigKey').value;
                     var connectionId = document.getElementById('connectionId').value;
+                    var params = document.getElementById('params').value;
+                    var config = {
+                        params: JSON.parse(params)
+                    };
 
                     var pizzly = new Pizzly('http://localhost:3003');
                     pizzly
-                        .auth(providerConfigKey, connectionId)
+                        .auth(providerConfigKey, connectionId, config)
                         .then((result) => {
                             var resultElement = document.getElementById('result');
                             resultElement.innerHTML = `SUCCESS: ${JSON.stringify(result)}`;


### PR DESCRIPTION
I have tested the OAuth flow and can confirm that it works.

To test it using the frontend, I added an additional field to the bin/sample page that has JSON you can fill in.
- Leaving it as an empty object (the default) will work with all providers that don't require any custom connection params
- Setting it to `{ "subdomain": "whatever" }` will allow Zendesk and Shopify to be tested easily.